### PR TITLE
Develop

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -2,6 +2,8 @@ Version 6-beta4 October  2020
   - fix: delete [] was thought as a type
   - fix: check if newname is a C/C++ keyword when Rename Symbol 
   - fix: correctly parse const keyword
+  - fix: correctly parse / code suggestion static class member methods/vars,
+  - enhancement: hide type name begin with '__' in variable defines.
   - enhancement: change the way cpp parser to handle inheritance, faster and less errors.
   - enhancement: Add _children to TStatement, to speedup symbol lookup
   - enhancement: use TStringHash to check if token text is a key word, speed parsing.

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -2,7 +2,7 @@ Version 6-beta4 October  2020
   - fix: delete [] was thought as a type
   - fix: check if newname is a C/C++ keyword when Rename Symbol 
   - fix: correctly parse const keyword
-  - fix: correctly parse / code suggestion static class member methods/vars,
+  - fix: correctly parse / code suggestion static class member methods/vars
   - enhancement: hide type name begin with '__' in variable defines.
   - enhancement: change the way cpp parser to handle inheritance, faster and less errors.
   - enhancement: Add _children to TStatement, to speedup symbol lookup

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,8 @@
 Version 6-beta4 October  2020
   - fix: delete [] was thought as a type
   - fix: check if newname is a C/C++ keyword when Rename Symbol 
+  - fix: correctly parse const keyword
+  - enhancement: change the way cpp parser to handle inheritance, faster and less errors.
   - enhancement: Add _children to TStatement, to speedup symbol lookup
   - enhancement: use TStringHash to check if token text is a key word, speed parsing.
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,7 @@
 Version 6-beta4 October  2020
   - fix: delete [] was thought as a type
   - fix: check if newname is a C/C++ keyword when Rename Symbol 
+  - enhancement: Add _children to TStatement, to speedup symbol lookup
   - enhancement: use TStringHash to check if token text is a key word, speed parsing.
 
 Version 6-beta3 October  2020

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -3,6 +3,7 @@ Version 6-beta4 October  2020
   - fix: check if newname is a C/C++ keyword when Rename Symbol 
   - fix: correctly parse const keyword
   - fix: correctly parse / code suggestion static class member methods/vars
+  - fix: correctly parse / code suggestion class member according to access privileges (including friend access).
   - enhancement: hide type name begin with '__' in variable defines.
   - enhancement: friend function support in code suggestion. (may not work when friend function are overloaded)
   - enhancement: change the way cpp parser to handle inheritance, faster and less errors.

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -4,6 +4,7 @@ Version 6-beta4 October  2020
   - fix: correctly parse const keyword
   - fix: correctly parse / code suggestion static class member methods/vars
   - enhancement: hide type name begin with '__' in variable defines.
+  - enhancement: friend function support in code suggestion. (may not work when friend function are overloaded)
   - enhancement: change the way cpp parser to handle inheritance, faster and less errors.
   - enhancement: Add _children to TStatement, to speedup symbol lookup
   - enhancement: use TStringHash to check if token text is a key word, speed parsing.

--- a/Source/Editor.pas
+++ b/Source/Editor.pas
@@ -1367,7 +1367,7 @@ begin
   fCompletionBox.OnKeyPress := CompletionKeyPress;
 
   // Filter the whole statement list
-  if fCompletionBox.Search(GetWordAtPosition(fText.CaretXY, wpCompletion)+key, fFileName, True)
+  if fCompletionBox.Search(GetWordAtPosition(fText.CaretXY, wpCompletion)+key, fFileName, False)
     and (key = '') then //only one suggestion and it's not input while typing
     CompletionInsert(); // if only have one suggestion, just use it 
 end;

--- a/Source/VCL/ClassBrowsing/CBUtils.pas
+++ b/Source/VCL/ClassBrowsing/CBUtils.pas
@@ -99,6 +99,7 @@ type
     _Temporary: boolean; // statements to be deleted after parsing
     _InProject: boolean; // statement in project
     _InSystemHeader: boolean; // statement in system header (#include <>)
+    _Children: TList; // Children Statement to speedup search
   end;
 
   TProgressEvent = procedure(Sender: TObject; const FileName: AnsiString; Total, Current: integer) of object;

--- a/Source/VCL/ClassBrowsing/CBUtils.pas
+++ b/Source/VCL/ClassBrowsing/CBUtils.pas
@@ -510,7 +510,6 @@ begin
   CppKeywords.Add('extern',Ord(skItself));
   CppKeywords.Add('false',Ord(skItself));
   CppKeywords.Add('for',Ord(skItself));
-  CppKeywords.Add('friend',Ord(skItself));
   CppKeywords.Add('mutable',Ord(skItself));
   CppKeywords.Add('noexcept',Ord(skItself));
   CppKeywords.Add('not',Ord(skItself));
@@ -601,14 +600,15 @@ begin
   // handled elsewhere
   CppKeywords.Add('class',Ord(skNone));
   CppKeywords.Add('enum',Ord(skNone));
+  CppKeywords.Add('friend',Ord(skItself));
   CppKeywords.Add('operator',Ord(skNone));
   CppKeywords.Add('private',Ord(skNone));
   CppKeywords.Add('protected',Ord(skNone));
   CppKeywords.Add('public',Ord(skNone));
+  CppKeywords.Add('static',Ord(skNone));
   CppKeywords.Add('struct',Ord(skNone));
   CppKeywords.Add('typedef',Ord(skNone));
   CppKeywords.Add('union',Ord(skNone));
-  CppKeywords.Add('static',Ord(skNone));
 
   // nullptr is value
   CppKeywords.Add('nullptr',Ord(skNone));

--- a/Source/VCL/ClassBrowsing/CBUtils.pas
+++ b/Source/VCL/ClassBrowsing/CBUtils.pas
@@ -498,7 +498,6 @@ begin
   CppKeywords.Add('bitor',Ord(skItself));
   CppKeywords.Add('break',Ord(skItself));
   CppKeywords.Add('compl',Ord(skItself));
-  CppKeywords.Add('const',Ord(skItself));
   CppKeywords.Add('constexpr',Ord(skItself));
   CppKeywords.Add('const_cast',Ord(skItself));
   CppKeywords.Add('continue',Ord(skItself));
@@ -510,7 +509,6 @@ begin
   CppKeywords.Add('false',Ord(skItself));
   CppKeywords.Add('for',Ord(skItself));
   CppKeywords.Add('friend',Ord(skItself));
-  CppKeywords.Add('inline',Ord(skItself));
   CppKeywords.Add('mutable',Ord(skItself));
   CppKeywords.Add('noexcept',Ord(skItself));
   CppKeywords.Add('not',Ord(skItself));
@@ -594,6 +592,10 @@ begin
   CppKeywords.Add('unsigned',Ord(skNone));
   CppKeywords.Add('void',Ord(skNone));
   CppKeywords.Add('wchar_t',Ord(skNone));
+
+  // it's part of type info
+  CppKeywords.Add('const',Ord(skNone));
+  CppKeywords.Add('inline',Ord(skItself));  
 
   // handled elsewhere
   CppKeywords.Add('class',Ord(skNone));

--- a/Source/VCL/ClassBrowsing/CBUtils.pas
+++ b/Source/VCL/ClassBrowsing/CBUtils.pas
@@ -100,7 +100,7 @@ type
     _InProject: boolean; // statement in project
     _InSystemHeader: boolean; // statement in system header (#include <>)
     _Children: TList; // Children Statement to speedup search
-    _Friends: TList; // friend class / functions
+    _Friends: TStringHash; // friend class / functions
     _Static: boolean; // static function / variable
   end;
 

--- a/Source/VCL/ClassBrowsing/CBUtils.pas
+++ b/Source/VCL/ClassBrowsing/CBUtils.pas
@@ -100,6 +100,8 @@ type
     _InProject: boolean; // statement in project
     _InSystemHeader: boolean; // statement in system header (#include <>)
     _Children: TList; // Children Statement to speedup search
+    _Friends: TList; // friend class / functions
+    _Static: boolean; // static function / variable
   end;
 
   TProgressEvent = procedure(Sender: TObject; const FileName: AnsiString; Total, Current: integer) of object;
@@ -518,7 +520,6 @@ begin
   CppKeywords.Add('or_eq',Ord(skItself));
   CppKeywords.Add('register',Ord(skItself));
   CppKeywords.Add('reinterpret_cast',Ord(skItself));
-  CppKeywords.Add('static',Ord(skItself));
   CppKeywords.Add('static_assert',Ord(skItself));
   CppKeywords.Add('static_cast',Ord(skItself));
   CppKeywords.Add('template',Ord(skItself));
@@ -595,7 +596,7 @@ begin
 
   // it's part of type info
   CppKeywords.Add('const',Ord(skNone));
-  CppKeywords.Add('inline',Ord(skItself));  
+  CppKeywords.Add('inline',Ord(skItself));
 
   // handled elsewhere
   CppKeywords.Add('class',Ord(skNone));
@@ -607,6 +608,7 @@ begin
   CppKeywords.Add('struct',Ord(skNone));
   CppKeywords.Add('typedef',Ord(skNone));
   CppKeywords.Add('union',Ord(skNone));
+  CppKeywords.Add('static',Ord(skNone));
 
   // nullptr is value
   CppKeywords.Add('nullptr',Ord(skNone));

--- a/Source/VCL/ClassBrowsing/CBUtils.pas
+++ b/Source/VCL/ClassBrowsing/CBUtils.pas
@@ -600,7 +600,7 @@ begin
   // handled elsewhere
   CppKeywords.Add('class',Ord(skNone));
   CppKeywords.Add('enum',Ord(skNone));
-  CppKeywords.Add('friend',Ord(skItself));
+  CppKeywords.Add('friend',Ord(skNone));
   CppKeywords.Add('operator',Ord(skNone));
   CppKeywords.Add('private',Ord(skNone));
   CppKeywords.Add('protected',Ord(skNone));

--- a/Source/VCL/ClassBrowsing/ClassBrowser.pas
+++ b/Source/VCL/ClassBrowsing/ClassBrowser.pas
@@ -234,7 +234,6 @@ var
   Statement, ParentStatement: PStatement;
   NewNode: TTreeNode;
   bInherited: boolean;
-  InheritanceStatements: TList;
 
   procedure AddStatementNode(StatementNode: PStatementNode);
   begin
@@ -257,12 +256,7 @@ begin
   else
     ParentStatement := nil;
 
-  InheritanceStatements := TList.Create;
-  try
     // allow inheritance propagation, including MI
-    if fShowInheritedMembers and (ParentStatement <> nil) and (ParentStatement^._Kind = skClass) then
-      fParser.GetMultipleInheritanceStatements(ParentStatement, InheritanceStatements);
-
     // Walk all the statements
     bInherited := False;
     StatementNode := StartNode;
@@ -281,9 +275,12 @@ begin
 
         // Stop the current recurse when we run out of children
         if _Parent <> ParentStatement then begin
+        {
           bInherited := fShowInheritedMembers and (InheritanceStatements.IndexOf(_Parent) <> -1);
           if not bInherited then
             Continue;
+        }
+          Continue;
         end;
 
         // Only do inheritance checking when absolutely needed
@@ -307,9 +304,6 @@ begin
         end;
       end;
     end;
-  finally
-    InheritanceStatements.Free;
-  end;
 end;
 
 procedure TClassBrowser.UpdateView;

--- a/Source/VCL/ClassBrowsing/CodeCompletion.pas
+++ b/Source/VCL/ClassBrowsing/CodeCompletion.pas
@@ -52,12 +52,10 @@ type
     fOnResize: TNotifyEvent;
     fOnlyGlobals: boolean;
     fCurrentStatement: PStatement;
-    fHideDelay: integer; // allow empty list once, then hide when empty again
     fIncludedFiles: TStringList;
     fIsIncludedCacheFileName: AnsiString;
     fIsIncludedCacheResult: boolean;
-    function ApplyClassFilter(Statement, CurrentClass: PStatement; InheritanceStatements: TList): boolean;
-    function ApplyMemberFilter(Statement, CurrentClass, ParentClass: PStatement; InheritanceStatements: TList): boolean;
+    function ApplyClassFilter(Statement, CurrentClass: PStatement): boolean;
     procedure GetCompletionFor(Phrase: AnsiString);
     procedure FilterList(const Member: AnsiString);
     procedure SetPosition(Value: TPoint);
@@ -124,7 +122,6 @@ begin
   fEnabled := True;
   fOnlyGlobals := False;
   fShowCount := 100; // keep things fast
-  fHideDelay := 0;
 
   fIsIncludedCacheFileName := '';
   fIsIncludedCacheResult := false;
@@ -139,56 +136,17 @@ begin
   inherited Destroy;
 end;
 
-function TCodeCompletion.ApplyClassFilter(Statement, CurrentClass: PStatement; InheritanceStatements: TList): boolean;
+function TCodeCompletion.ApplyClassFilter(Statement, CurrentClass: PStatement): boolean;
 begin
   Result :=
     (
-    (Statement^._Scope in [ssLocal, ssGlobal]) or // local or global var or
-    (
-    (Statement^._Scope = ssClassLocal) and // class var
-    (
-    (Statement^._Parent = CurrentClass) or // from current class
-    (
-    (InheritanceStatements.IndexOf(Statement^._Parent) <> -1) and
-    (Statement^._ClassScope <> scsPrivate)
-    ) // or an inheriting class
-    )
-    )
-    ) and
-    (IsIncluded(Statement^._FileName) or
-    IsIncluded(Statement^._DefinitionFileName));
-end;
-
-function TCodeCompletion.ApplyMemberFilter(Statement, CurrentClass, ParentClass: PStatement; InheritanceStatements:
-  TList): boolean;
-var
-  cs: set of TStatementClassScope;
-begin
-  Result := Statement^._Parent <> nil; // only members
-  if not Result then
-    Exit;
-
-  // all members of current class
-  Result := Result and ((ParentClass = CurrentClass) and (Statement^._Parent = ParentClass));
-
-  // all public and published members of var's class
-  Result := Result or
-    (
-    (ParentClass = Statement^._Parent) and
-    (not (Statement^._ClassScope in [scsProtected, scsPrivate]))
-    // or member of an inherited class
-    );
-
-  if (CurrentClass = nil) or (Statement^._Parent = CurrentClass) then
-    cs := [scsPrivate, scsProtected]
-  else
-    cs := [scsPrivate];
-
-  // all inherited class's non-private members
-  Result := Result or
-    (
-    (InheritanceStatements.IndexOf(Statement^._Parent) <> -1) and
-    (not (Statement^._ClassScope in cs)) // or member of an inherited class
+      (Statement^._Scope in [ssLocal, ssGlobal]) or // local or global var or
+      ( (Statement^._Scope = ssClassLocal) and // class var
+        (Statement^._Parent = CurrentClass) // from current class
+      )
+    ) and (
+      IsIncluded(Statement^._FileName) or
+      IsIncluded(Statement^._DefinitionFileName)
     );
 end;
 
@@ -196,35 +154,27 @@ procedure TCodeCompletion.GetCompletionFor(Phrase: AnsiString);
 var
   Node: PStatementNode;
   Statement: PStatement;
-  I: integer;
-  InheritanceStatements: TList;
+  I,t: integer;
   ParentStatement, ParentTypeStatement, CurrentStatementParent: PStatement;
+  Children : TList;
+  isThis: boolean;
 begin
   // Reset filter cache
   fIsIncludedCacheFileName := '';
   fIsIncludedCacheResult := false;
 
   // Pulling off the same trick as in TCppParser.FindStatementOf, but ignore everything after last operator
-  InheritanceStatements := TList.Create;
-  try
     I := fParser.FindLastOperator(Phrase);
     if I = 0 then begin
 
       // only add globals and members of the current class
 
       // Also consider classes the current class inherits from
-      fParser.GetMultipleInheritanceStatements(fCurrentStatement, InheritanceStatements);
       Node := fParser.Statements.FirstNode;
       while Assigned(Node) do begin
         Statement := Node^.Data;
-        if ApplyClassFilter(Statement, fCurrentStatement, InheritanceStatements) then begin
-          if (fFullCompletionStatementList.Count = 0) or
-            (not (
-              SameStr(
-                PStatement(fFullCompletionStatementList[fFullCompletionStatementList.Count-1])^._Command,
-                Statement^._Command)
-             ) ) then
-            fFullCompletionStatementList.Add(Statement);
+        if ApplyClassFilter(Statement, fCurrentStatement) then begin
+          fFullCompletionStatementList.Add(Statement);
         end;
         Node := Node^.NextNode;
       end;
@@ -246,35 +196,31 @@ begin
         Exit;
 
       // Then determine which type it has (so we can use it as a parent)
-      if ParentStatement^._Kind = skClass then // already found type
-        ParentTypeStatement := ParentStatement
-      else
-        ParentTypeStatement := fParser.FindTypeDefinitionOf(ParentStatement^._Type, CurrentStatementParent);
-      // TODO: should not be nil
-      if not Assigned(ParentTypeStatement) then
-        Exit;
-
-      // Then add members of the ClassIDs and InheritanceIDs
-      fParser.GetMultipleInheritanceStatements(ParentTypeStatement, InheritanceStatements);
-
-      Node := fParser.Statements.FirstNode;
-      while Assigned(Node) do begin
-        Statement := Node^.Data;
-        if ApplyMemberFilter(Statement, fCurrentStatement, ParentTypeStatement, InheritanceStatements)then begin
-          if (fFullCompletionStatementList.Count = 0) or
-            (not (
-              SameStr(
-                PStatement(fFullCompletionStatementList[fFullCompletionStatementList.Count-1])^._Command,
-                Statement^._Command)
-             ) ) then
+      if (ParentStatement^._Kind = skClass) then begin
+        //todo It's a class/struct name , we should show static fields only;
+        Children := fParser.Statements.GetChildrenStatements(fCurrentStatement);
+        if Assigned(Children) then begin
+          for t:=0 to Children.Count-1 do begin
+            Statement := PStatement(Children[t]);
             fFullCompletionStatementList.Add(Statement);
+          end;
         end;
-        Node := Node^.NextNode;
+      end else begin
+        //It's a var/method, we should show it's types member
+        ParentTypeStatement := fParser.FindTypeDefinitionOf(ParentStatement^._Type, CurrentStatementParent);
+        if Assigned(ParentTypeStatement) then begin
+          isThis :=  SameStr(ParentStatement^._Command,'this');
+          Children := fParser.Statements.GetChildrenStatements(ParentTypeStatement);
+          if Assigned(Children) then begin
+            for t:=0 to Children.Count-1 do begin
+              Statement := PStatement(Children[t]);
+              if (isThis) or (Statement^._ClassScope in [scsPublic,scsNone]) then
+                fFullCompletionStatementList.Add(Statement);
+            end;
+          end;
+        end;
       end;
     end;
-  finally
-    InheritanceStatements.Free;
-  end;
 end;
 
 // Return 1 to show Item2 above Item1, otherwise -1
@@ -306,16 +252,31 @@ end;
 procedure TCodeCompletion.FilterList(const Member: AnsiString);
 var
   I: integer;
+  tmpList:TList;
+  lastCmd:String;
 begin
   fCompletionStatementList.Clear;
-  if Member <> '' then begin // filter, case insensitive
-    fCompletionStatementList.Capacity := fFullCompletionStatementList.Count;
-    for I := 0 to fFullCompletionStatementList.Count - 1 do
-      if StartsStr(Member, PStatement(fFullCompletionStatementList[I])^._Command) then
-        fCompletionStatementList.Add(fFullCompletionStatementList[I]);
-  end else
-    fCompletionStatementList.Assign(fFullCompletionStatementList);
-  fCompletionStatementList.Sort(@ListSort);
+  tmpList:=TList.Create;
+  try
+    if Member <> '' then begin // filter, case sensitive
+      tmpList.Capacity := fFullCompletionStatementList.Count;
+      for I := 0 to fFullCompletionStatementList.Count - 1 do
+        if StartsStr(Member, PStatement(fFullCompletionStatementList[I])^._Command) then
+          tmpList.Add(fFullCompletionStatementList[I]);
+    end else
+      tmpList.Assign(fFullCompletionStatementList);
+    tmpList.sort(@ListSort);
+    // filter duplicates
+    lastCmd := '';
+    for I:=0 to tmpList.Count -1 do begin
+      if lastCmd <> PStatement(tmpList[I])^._Command then
+         fCompletionStatementList.Add(tmpList[I]);
+      lastCmd:=PStatement(tmpList[I])^._Command;
+    end;
+  finally
+    tmpList.Free;
+  end;
+
 end;
 
 procedure TCodeCompletion.Hide;
@@ -338,6 +299,12 @@ var
   symbol: ansistring;
 begin
   Result:=False;
+
+  if Phrase = '' then begin
+    Hide;
+    Exit;
+  end;
+    
   if fEnabled then begin
 
     Screen.Cursor := crHourglass;
@@ -392,11 +359,8 @@ begin
       CodeComplForm.lbCompletion.SetFocus;
       if CodeComplForm.lbCompletion.Items.Count > 0 then
         CodeComplForm.lbCompletion.ItemIndex := 0;
-      fHideDelay := 0;
-    end else if fHideDelay = 0 then begin
-      CodeComplForm.lbCompletion.Items.Clear;
-      fHideDelay := 1;
     end else begin
+      CodeComplForm.lbCompletion.Items.Clear;
       Hide;
     end;
 

--- a/Source/VCL/ClassBrowsing/CodeCompletion.pas
+++ b/Source/VCL/ClassBrowsing/CodeCompletion.pas
@@ -311,7 +311,7 @@ begin
   if Member <> '' then begin // filter, case insensitive
     fCompletionStatementList.Capacity := fFullCompletionStatementList.Count;
     for I := 0 to fFullCompletionStatementList.Count - 1 do
-      if StartsText(Member, PStatement(fFullCompletionStatementList[I])^._Command) then
+      if StartsStr(Member, PStatement(fFullCompletionStatementList[I])^._Command) then
         fCompletionStatementList.Add(fFullCompletionStatementList[I]);
   end else
     fCompletionStatementList.Assign(fFullCompletionStatementList);

--- a/Source/VCL/ClassBrowsing/CodeCompletion.pas
+++ b/Source/VCL/ClassBrowsing/CodeCompletion.pas
@@ -198,11 +198,14 @@ begin
       // Then determine which type it has (so we can use it as a parent)
       if (ParentStatement^._Kind = skClass) then begin
         //todo It's a class/struct name , we should show static fields only;
-        Children := fParser.Statements.GetChildrenStatements(fCurrentStatement);
+        Children := fParser.Statements.GetChildrenStatements(ParentStatement);
         if Assigned(Children) then begin
           for t:=0 to Children.Count-1 do begin
             Statement := PStatement(Children[t]);
-            fFullCompletionStatementList.Add(Statement);
+            if (Statement^._Static) and
+              ((Statement^._ClassScope in [scsPublic,scsNone])
+              or (ParentStatement = fCurrentStatement)) then
+              fFullCompletionStatementList.Add(Statement);
           end;
         end;
       end else begin

--- a/Source/VCL/ClassBrowsing/CodeCompletion.pas
+++ b/Source/VCL/ClassBrowsing/CodeCompletion.pas
@@ -205,7 +205,12 @@ begin
             //todo: friend class / function support
             if (Statement^._Static) and
               ((Statement^._ClassScope in [scsPublic,scsNone])
-              or (ParentStatement = fCurrentStatement)) then
+                or (ParentStatement = fCurrentStatement)) //we are inside the class
+                or (                                     // we are inside the classes friend
+                    (Assigned(ParentStatement^._Friends) and
+                    (ParentStatement^._Friends.IndexOf(fCurrentStatement)<>-1)
+                    )
+               ) then
               fFullCompletionStatementList.Add(Statement);
           end;
         end;

--- a/Source/VCL/ClassBrowsing/CodeCompletion.pas
+++ b/Source/VCL/ClassBrowsing/CodeCompletion.pas
@@ -202,6 +202,7 @@ begin
         if Assigned(Children) then begin
           for t:=0 to Children.Count-1 do begin
             Statement := PStatement(Children[t]);
+            //todo: friend class / function support
             if (Statement^._Static) and
               ((Statement^._ClassScope in [scsPublic,scsNone])
               or (ParentStatement = fCurrentStatement)) then
@@ -217,6 +218,7 @@ begin
           if Assigned(Children) then begin
             for t:=0 to Children.Count-1 do begin
               Statement := PStatement(Children[t]);
+            //todo: friend class / function support
               if (isThis) or (Statement^._ClassScope in [scsPublic,scsNone]) then
                 fFullCompletionStatementList.Add(Statement);
             end;

--- a/Source/VCL/ClassBrowsing/CppParser.pas
+++ b/Source/VCL/ClassBrowsing/CppParser.pas
@@ -342,6 +342,10 @@ var
   Statement: PStatement;
 begin
   Result := name;
+  if StartsStr("__",name) then begin
+    Result := ''
+    Exit;
+  end;
   Statement := FindMacroDefine(name);
   if Assigned(Statement) then begin
     if (Statement^._Value <> '') then
@@ -509,6 +513,7 @@ var
       _InProject := fIsProjectFile;
       _InSystemHeader := fIsSystemHeader;
       _Children := nil;
+      _Friends := nil;
       _Static := isStatic;
     end;
     fStatementList.Add(Result);
@@ -894,7 +899,7 @@ begin
       if SameStr(s, 'static') then
         IsStatic := True;
       if s<>'' then
-        sType := sType + s;
+        sType := sType + ' '+ s;
       bTypeOK := sType <> '';
     end;
     Inc(fIndex);
@@ -1517,7 +1522,7 @@ begin
       (not SameStr(fTokenizer[fIndex]^.Text, 'union')) then  begin
       s:=expandMacroType(fTokenizer[fIndex]^.Text);
       if s<>'' then
-        LastType := LastType + expandMacroType(fTokenizer[fIndex]^.Text);
+        LastType := LastType + ' '+expandMacroType(fTokenizer[fIndex]^.Text);
       if SameStr(s,'static') then
         isStatic := True;
     end;
@@ -3002,7 +3007,8 @@ begin
       _Temporary := derived^._Temporary; // true if it's added by a function body scan
       _InProject := derived^._InProject;
       _InSystemHeader := derived^._InSystemHeader;
-      _Children := nil;
+      _Children := nil; //Todo: inner class inheritance?
+      _Friends := nil; // Friends are not inherited;
       _Static := derived^._Static;
     end;
     fStatementList.Add(Result);

--- a/Source/VCL/ClassBrowsing/CppParser.pas
+++ b/Source/VCL/ClassBrowsing/CppParser.pas
@@ -123,7 +123,6 @@ type
     function CheckForPreprocessor: boolean;
     function CheckForKeyword: boolean;
 
-    function CheckForNamespace: boolean;
     function CheckForTypedef: boolean;
     function CheckForTypedefEnum: boolean;
     function CheckForTypedefStruct: boolean;
@@ -1338,8 +1337,10 @@ begin
   FunctionClass := GetLastCurrentClass;
   if (fIndex < fTokenizer.Tokens.Count) and (fTokenizer[fIndex]^.Text[1] in [';', '}']) then begin // prototype
     IsDeclaration := True;
+    {
     if not fIsHeader and not Assigned(FunctionClass) then // in a CPP file
       IsValid := False; // not valid
+    }
   end else begin
 
     // Find the function body start after the inherited constructor
@@ -1350,8 +1351,11 @@ begin
     // Still a prototype
     if (fIndex < fTokenizer.Tokens.Count) and (fTokenizer[fIndex]^.Text[1] in [';', '}']) then begin
       IsDeclaration := True;
+      //Forward declaration, that's ok
+      {
       if not fIsHeader and not Assigned(FunctionClass) then
         IsValid := False;
+      }
     end;
   end;
 
@@ -2410,6 +2414,7 @@ begin
       fLaterScanning := False;
     end;
   end;
+  Result := ClosestStatement;
 end;
 
 function TCppParser.GetClass(const Phrase: AnsiString): AnsiString;

--- a/Source/VCL/ClassBrowsing/StatementList.pas
+++ b/Source/VCL/ClassBrowsing/StatementList.pas
@@ -252,9 +252,9 @@ end;
 
 function TStatementList.GetChildrenStatements(Statement:PStatement): TList;
 begin
-  if (Assigned(Statement)) then
+  if (Assigned(Statement)) then begin
     Result:= Statement._Children
-  else
+  end else
     Result:=fGlobalStatements;
 end;
 end.

--- a/Source/VCL/ClassBrowsing/StatementList.pas
+++ b/Source/VCL/ClassBrowsing/StatementList.pas
@@ -148,6 +148,8 @@ begin
       PStatement(Node^.Data)^._InheritanceList.Free;
     if Assigned(PStatement(Node^.Data)^._Children) then
       PStatement(Node^.Data)^._Children.Free;
+    if Assigned(PStatement(Node^.Data)^._Friends) then
+      PStatement(Node^.Data)^._Friends.Free;
     Dispose(PStatement(Node^.Data));
   end;
   Dispose(Node);

--- a/Source/VCL/ClassBrowsing/StatementList.pas
+++ b/Source/VCL/ClassBrowsing/StatementList.pas
@@ -39,6 +39,7 @@ type
     fFirstNode: PStatementNode;
     fLastNode: PStatementNode;
     fOwnsObjects: boolean;
+    fGlobalStatements: TList;
     procedure DisposeNode(Node: PStatementNode);
     procedure OnNodeAdding(Node: PStatementNode); // call when about to add this node
     procedure OnNodeDeleting(Node: PStatementNode); // call when about to delete this node
@@ -53,6 +54,7 @@ type
     function Delete(Node: PStatementNode): Integer; overload;
     function Delete(Data: PStatement): Integer; overload;
     function DeleteFromTo(FromNode, ToNode: PStatementNode): Integer;
+    function GetChildrenStatements(Statement:PStatement): TList;
     procedure Clear;
     property FirstNode: PStatementNode read fFirstNode;
     property LastNode: PStatementNode read fLastNode;
@@ -70,11 +72,13 @@ begin
   fLastNode := nil;
   fCount := 0;
   fOwnsObjects := True;
+  fGlobalStatements := TList.Create;
 end;
 
 destructor TStatementList.Destroy;
 begin
   Clear;
+  fGlobalStatements.Free;
 end;
 
 function TStatementList.FirstStatement: PStatement;
@@ -115,19 +119,35 @@ end;
 function TStatementList.Add(Data: PStatement): Integer;
 var
   Node: PStatementNode;
+  parent: PStatement;
 begin
   // Create a new one
   Node := New(PStatementNode);
   Node^.Data := Data;
   OnNodeAdding(Node);
   Result := fCount;
+  if Assigned(Data^._Parent) then begin
+    parent := Data^._Parent;
+    if not Assigned(parent^._Children) then
+      parent^._Children := TList.Create;
+    parent^._Children.Add(Data);
+  end else begin
+    fGlobalStatements.Add(Data);
+  end;
 end;
 
 procedure TStatementList.DisposeNode(Node: PStatementNode);
 begin
+  if Assigned(Node^.Data^._Parent) then
+    Node^.Data^._Parent._Children.remove(Node^.Data)
+  else
+    fGlobalStatements.Remove(Node^.Data);
   if OwnsObjects then begin
     if Assigned(PStatement(Node^.Data)._InheritanceList) then
       PStatement(Node^.Data)._InheritanceList.Free;
+    if Assigned(PStatement(Node^.Data)._Children) then
+      PStatement(Node^.Data)._InheritanceList.Free;
+      // remove it from parent's children
     Dispose(PStatement(Node^.Data));
   end;
   Dispose(Node);
@@ -225,7 +245,15 @@ begin
   fFirstNode := nil;
   fLastNode := nil;
   fCount := 0;
+  fGlobalStatements.Clear;
 end;
 
+function TStatementList.GetChildrenStatements(Statement:PStatement): TList;
+begin
+  if (Assigned(Statement)) then
+    Result:= Statement._Children
+  else
+    Result:=fGlobalStatements;
+end;
 end.
 

--- a/Source/VCL/ClassBrowsing/StatementList.pas
+++ b/Source/VCL/ClassBrowsing/StatementList.pas
@@ -138,16 +138,16 @@ end;
 
 procedure TStatementList.DisposeNode(Node: PStatementNode);
 begin
+  // remove it from parent's children
   if Assigned(Node^.Data^._Parent) then
     Node^.Data^._Parent._Children.remove(Node^.Data)
   else
     fGlobalStatements.Remove(Node^.Data);
   if OwnsObjects then begin
-    if Assigned(PStatement(Node^.Data)._InheritanceList) then
-      PStatement(Node^.Data)._InheritanceList.Free;
-    if Assigned(PStatement(Node^.Data)._Children) then
-      PStatement(Node^.Data)._InheritanceList.Free;
-      // remove it from parent's children
+    if Assigned(PStatement(Node^.Data)^._InheritanceList) then
+      PStatement(Node^.Data)^._InheritanceList.Free;
+    if Assigned(PStatement(Node^.Data)^._Children) then
+      PStatement(Node^.Data)^._Children.Free;
     Dispose(PStatement(Node^.Data));
   end;
   Dispose(Node);

--- a/Source/main.pas
+++ b/Source/main.pas
@@ -5614,7 +5614,22 @@ var
   Node: PStatementNode;
   Statement, ParentStatement: PStatement;
   procedure AddStatementKind(AddKind: TStatementKind);
+  var
+    i:integer;
+    children: TList;
   begin
+    children := CppParser.Statements.GetChildrenStatements(ParentStatement);
+    if Assigned(Children) then begin
+      for i:=0 to Children.Count-1 do
+      begin
+        Statement := PStatement(Children[i]);
+        if  Statement^._InProject and (Statement^._Kind = AddKind) then
+          cmbMembers.Items.AddObject(CppParser.StatementKindStr(AddKind) + ' ' + Statement^._Command + Statement^._Args +
+            ' : ' + Statement^._Type,
+            Pointer(Statement));
+      end;
+    end;
+    {
     Node := CppParser.Statements.FirstNode;
     while Assigned(Node) do begin
       Statement := Node^.Data;
@@ -5624,6 +5639,7 @@ var
           Pointer(Statement));
       Node := Node^.NextNode;
     end;
+    }
   end;
 begin
   cmbMembers.Items.BeginUpdate;

--- a/Source/main.pas
+++ b/Source/main.pas
@@ -5629,17 +5629,6 @@ var
             Pointer(Statement));
       end;
     end;
-    {
-    Node := CppParser.Statements.FirstNode;
-    while Assigned(Node) do begin
-      Statement := Node^.Data;
-      if (Statement^._Parent = ParentStatement) and Statement^._InProject and (Statement^._Kind = AddKind) then
-        cmbMembers.Items.AddObject(CppParser.StatementKindStr(AddKind) + ' ' + Statement^._Command + Statement^._Args +
-          ' : ' + Statement^._Type,
-          Pointer(Statement));
-      Node := Node^.NextNode;
-    end;
-    }
   end;
 begin
   cmbMembers.Items.BeginUpdate;

--- a/Source/main.pas
+++ b/Source/main.pas
@@ -1010,6 +1010,7 @@ begin
   // Try to close the current project. If it stays open (user says cancel), stop quitting
   if Assigned(fProject) then
     actCloseProjectExecute(Self);
+    
   if Assigned(fProject) then begin
     Action := caNone;
     Exit;

--- a/Source/main.pas
+++ b/Source/main.pas
@@ -5611,7 +5611,6 @@ end;
 
 procedure TMainForm.cmbClassesChange(Sender: TObject);
 var
-  Node: PStatementNode;
   Statement, ParentStatement: PStatement;
   procedure AddStatementKind(AddKind: TStatementKind);
   var

--- a/TODO.txt
+++ b/TODO.txt
@@ -31,6 +31,14 @@ Unittest support (doctest?google test?)
 git support?
 Refactor -> extract variable/ extract const / extract define
 rename symbol in project files
-compiler settings -> change project compiler set will lost settings?
+compiler settings -> change project compiler set will lost settings? ( no need)
+complete container library (must test it thoroughly)
+use hash to speed up symbol lookup 
+parsing namespace 
+parsing using namespace
+
+
+
+
 
 


### PR DESCRIPTION
  - fix: delete [] was thought as a type
  - fix: check if newname is a C/C++ keyword when Rename Symbol 
  - fix: correctly parse const keyword
  - fix: correctly parse / code suggestion static class member methods/vars
  - fix: correctly parse / code suggestion class member according to access privileges (including friend access).
  - enhancement: hide type name begin with '__' in variable defines.
  - enhancement: friend function support in code suggestion. (may not work when friend function are overloaded)
  - enhancement: change the way cpp parser to handle inheritance, faster and less errors.
  - enhancement: Add _children to TStatement, to speedup symbol lookup
  - enhancement: use TStringHash to check if token text is a key word, speed parsing.