### PR TITLE
Version 5.1, fix crashes

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,6 @@
 Version 6-beta5.1 October  2020
   - fix: only update class browser when file is open/save, in case it refreshes frequently.
+  - fix: #define in header files lost when reparsing files
 
 Version 6-beta5 October  2020
   - fix: Select row in Class Browser

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,6 @@
+Version 6-beta5.1 October  2020
+  - fix: only update class browser when file is open/save, in case it refreshes frequently.
+
 Version 6-beta5 October  2020
   - fix: Select row in Class Browser
   - fix: icons in Class Browser

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,7 @@
 Version 6-beta5.1 October  2020
   - fix: only update class browser when file is open/save, in case it refreshes frequently.
   - fix: #define in header files lost when reparsing files
+  - fix: crash when exit if Class B inheritanced Class A, and Class C inherited Class B
 
 Version 6-beta5 October  2020
   - fix: Select row in Class Browser

--- a/README.md
+++ b/README.md
@@ -7,18 +7,24 @@ It's intended to be used for eductional purposes.
 中文网站在这里 https://royqh.net/devcpp/
 
 HighLights of News:
- * Greatly improved "Auto symbol completion" function. Autoskip matched )/}/]/"/', never need to delete it or skip it manually. This makes code input much fluent.
- * Fix auto-indent; When } is inputted, its line will intend to the same as the matching {.
  * Greatly improved "Auto Code Completion":
    * Fixed header parsing error. Can correctly show type hints for std::string, for example.
    * Auto code suggestion while typing.
    * In editor option dialog, user can choose to use Alt+/ instead of Ctrl+Space to call Code Completion Action. (In chinese systems, Ctrl-Space is used for switching input methods). And if there is only one code suggestion candidate, it is auto used and the suggestion form will not be displayed. This will speed the input.
    * Suggestion form can capture TAB keypress event now.
- * Debugger Improve:
+ * Greatly improved Debugger:
    * breakpoints on condition
    * Redesigned Debugger panel, add Call Stack / Breakpoints sheet
    * Debug Output window can hide all annotions of the output. This makes it much better to look, and we can use it just like using a gdb console.
    * If no breakpoint is set, the debugged program will pause at the entrance of main().
+ * Greatly improved ClassBrowser:
+   * Correctly show #define/typedef/enum/class/struct/global var/function infos
+   * sort by type/ alphabetically
+   * show/hide inherited members
+   * correctly differentiate static class members / class members;
+ * Greatly improved Code Parser, faster and less error;
+ * Greatly improved "Auto symbol completion" function. Autoskip matched )/}/]/"/', never need to delete it or skip it manually. This makes code input much fluent.
+ * Fix auto-indent; When } is inputted, its line will intend to the same as the matching {.
  * GDB 9.2 and GCC 9.2
  * User can open/edit/save/compile UTF-8 encoding files.
  * rename symbol

--- a/Source/Editor.pas
+++ b/Source/Editor.pas
@@ -1364,7 +1364,7 @@ begin
     // Reparse whole file (not function bodies) if it has been modified
     // use stream, don't read from disk (not saved yet)
     if fText.Modified then begin
-      MainForm.CppParser.ParseFile(fFileName, InProject, False, True, M);
+      MainForm.CppParser.ParseFile(fFileName, InProject, False, False, M);
     end;
 
     // Scan the current function body

--- a/Source/VCL/ClassBrowsing/CBUtils.pas
+++ b/Source/VCL/ClassBrowsing/CBUtils.pas
@@ -360,7 +360,7 @@ var
   I: integer;
   Dir: AnsiString;
 begin
-  Result := FileName;
+  Result := StringReplace(FileName,'/','\',[rfReplaceAll]);
 
   // Try to convert a C++ filename from cxxx to xxx.h (ignore std:: namespace versions)
   if StartsStr('c', Result) and not EndsStr('.h', Result) and not ContainsStr(Result, '.') then begin

--- a/Source/VCL/ClassBrowsing/ClassBrowser.pas
+++ b/Source/VCL/ClassBrowsing/ClassBrowser.pas
@@ -309,14 +309,16 @@ begin
               if _InSystemHeader and IsIncluded(_FileName) then
                 AddStatement(Statement); // only show system header stuff
             end;
-            sfCurrent: begin
-              if not _InSystemHeader and IsIncluded(_FileName) then
-                AddStatement(Statement);
-            end;
             sfProject: begin
               if _InProject then
                 AddStatement(Statement);
             end;
+            {
+            sfCurrent: begin
+              if not _InSystemHeader and IsIncluded(_FileName) then
+                AddStatement(Statement);
+            end;
+            }
           end;
         end;
       end;

--- a/Source/VCL/ClassBrowsing/CppParser.pas
+++ b/Source/VCL/ClassBrowsing/CppParser.pas
@@ -2377,7 +2377,6 @@ begin
         fPreprocessor.SetScannedFileList(fScannedFiles);
         fPreprocessor.SetScanOptions(fParseGlobalHeaders, fParseLocalHeaders);
         fPreprocessor.PreProcessStream(FileName, Stream);
-
         // Tokenize the stream so we can find the start and end of the function body
         fTokenizer.TokenizeBuffer(PAnsiChar(fPreprocessor.Result));
       end;

--- a/Source/VCL/ClassBrowsing/CppParser.pas
+++ b/Source/VCL/ClassBrowsing/CppParser.pas
@@ -1853,14 +1853,14 @@ begin
     Exit;
   end;
 
-
+  {
   with TStringList.Create do try
     Text:=fPreprocessor.Result;
     SaveToFile('f:\\result.txt');
   finally
     Free;
   end;
-
+  }
   // Tokenize the preprocessed buffer file
   try
     fTokenizer.TokenizeBuffer(PAnsiChar(fPreprocessor.Result));
@@ -3066,7 +3066,12 @@ begin
       _Args := inherit^._Args;
       _Value := inherit^._Value;
       _Kind := inherit^._Kind;
-      _InheritanceList := inherit^._InheritanceList;
+      if Assigned(inherit^._InheritanceList) then begin
+      // we should copy it, or we will got trouble when clear StatementList
+        _InheritanceList := TList.Create;
+        _InheritanceList.Assign(inherit^._InheritanceList);
+      end else
+        _InheritanceList := nil;
       _Scope := inherit^._Scope;
       _ClassScope := access;
       _HasDefinition := inherit^._HasDefinition;

--- a/Source/VCL/ClassBrowsing/CppParser.pas
+++ b/Source/VCL/ClassBrowsing/CppParser.pas
@@ -1001,6 +1001,9 @@ begin
   // Skip typedef word
   Inc(fIndex);
 
+  if (fIndex>=fTokenizer.Tokens.Count) then
+    Exit;
+
   if fTokenizer[fIndex]^.Text[1] in ['(', ',', ';'] then begin // error typedef
     //skip to ;
     while (fIndex< fTokenizer.Tokens.Count) and not (fTokenizer[fIndex]^.Text[1] = ';') do
@@ -1850,14 +1853,14 @@ begin
     Exit;
   end;
 
-  {
+
   with TStringList.Create do try
     Text:=fPreprocessor.Result;
     SaveToFile('f:\\result.txt');
   finally
     Free;
   end;
-  }
+
   // Tokenize the preprocessed buffer file
   try
     fTokenizer.TokenizeBuffer(PAnsiChar(fPreprocessor.Result));
@@ -1881,7 +1884,7 @@ begin
   try
     repeat
     until not HandleStatement;
-    //Statements.DumpTo('f:\\statements.txt');
+   // Statements.DumpTo('f:\\statements.txt');
   finally
     //fSkipList:=-1; // remove data from memory, but reuse structures
     fCurrentClass.Clear;
@@ -2324,18 +2327,14 @@ begin
             end;
         end;
       skFunction, skConstructor, skDestructor: begin
+          if SameFileName(Statement^._FileName, Filename) then begin
           // Check definition
-          if Statement^._HasDefinition and SameFileName(Statement^._DefinitionFileName, Filename) then begin
-            if (Statement^._DefinitionLine <= Row) and (Statement^._DefinitionLine > ClosestLine) then begin
+            if Statement^._HasDefinition and (Statement^._DefinitionLine <= Row) and (Statement^._DefinitionLine > ClosestLine) then begin
               ClosestStatement := Statement;
               ClosestLine := Statement^._DefinitionLine;
               InsideBody := Statement^._Line < Row;
-            end;
-          end;
-
-          // Check declaration
-          if SameFileName(Statement^._FileName, Filename) then begin
-            if (Statement^._Line <= Row) and (Statement^._Line > ClosestLine) then begin
+            end else if (Statement^._Line <= Row) and (Statement^._Line > ClosestLine) then begin
+              // Check declaration
               ClosestStatement := Statement;
               ClosestLine := Statement^._Line;
               InsideBody := True; // no body, so assume true

--- a/Source/VCL/ClassBrowsing/CppPreprocessor.pas
+++ b/Source/VCL/ClassBrowsing/CppPreprocessor.pas
@@ -42,7 +42,7 @@ type
   PFile = ^TFile;
   TFile = record
     Index: integer; // 0-based for programming convenience
-    FileName: AnsiString;
+    FileName: AnsiString; // Record filename, but not used now
     Buffer: TStringList; // do not concat them all
     Branches: integer; //branch levels;
   end;
@@ -52,6 +52,7 @@ type
     Name: AnsiString;
     Args: AnsiString;
     Value: AnsiString;
+    FileName: AnsiString;
     HardCoded: boolean; // if true, don't free memory (points to hard defines)
   end;
 
@@ -450,6 +451,7 @@ begin
   Item^.Name := Name;
   Item^.Args := Args;
   Item^.Value := Value;
+  Item^.FileName := fFileName;
   Item^.HardCoded := HardCoded;
   if HardCoded then
     fHardDefines.AddObject(Name, Pointer(Item)) // uses TStringList too to be able to assign to fDefines easily
@@ -524,22 +526,29 @@ end;
 procedure TCppPreprocessor.ResetDefines;
 var
   I: integer;
+  define : PDefine;
 begin
-  // Assign hard list to soft list
-  for I := 0 to fDefines.Count - 1 do begin // remove memory first
-    if not PDefine(fDefines.Objects[i])^.HardCoded then // memory belongs to hardcoded list
-      Dispose(PDefine(fDefines.Objects[i]));
+   // todo how to decide which headers is not included anymore?
+  fDefines.Sorted := False;
+  I:=0;
+  while (fDefines.Count>0) and (I < fDefines.Count) do begin
+    define := PDefine(fDefines.Objects[i]);
+    if define^.HardCoded then begin //remove hard defines but don't remove node
+      fDefines.Delete(I);
+    end else if SameStr(fFileName, define^.FileName) then begin// remove defines of file to be reprocessed
+      Dispose(define);
+      fDefines.Delete(I);
+    end else
+      Inc(I);
   end;
 
-  // Assign does clear too
-  fDefines.Duplicates := dupAccept;
-  fDefines.Sorted := False;
-  try
-    fDefines.Assign(fHardDefines); // then assign
-  finally
-    fDefines.Duplicates := dupAccept;
-    fDefines.Sorted := True; // sort once
+  for i:=0 to fHardDefines.Count -1 do
+  begin
+    define := PDefine(fHardDefines.Objects[i]);
+    fDefines.AddObject(define^.Name,Pointer(define));
   end;
+
+  fDefines.Sorted := True;
 end;
 
 procedure TCppPreprocessor.HandlePreprocessor(const Value: AnsiString);
@@ -1032,6 +1041,7 @@ end;
 
 procedure TCppPreprocessor.PreprocessStream(const FileName: AnsiString; Stream: TMemoryStream);
 begin
+  fFileName:=FileName;
   Reset;
   OpenInclude(FileName, Stream);
   PreprocessBuffer;
@@ -1039,6 +1049,7 @@ end;
 
 procedure TCppPreprocessor.PreprocessFile(const FileName: AnsiString);
 begin
+  fFileName:=FileName;
   Reset;
   OpenInclude(FileName, nil);
 //  fBuffer.SaveToFile('f:\\buffer.txt');

--- a/Source/VCL/ClassBrowsing/CppPreprocessor.pas
+++ b/Source/VCL/ClassBrowsing/CppPreprocessor.pas
@@ -150,13 +150,13 @@ begin
     Dispose(PFile(fIncludes[i]));
   end;
   fIncludes.Free;
-  for I := 0 to fHardDefines.Count - 1 do
-    Dispose(PDefine(fHardDefines.Objects[i]));
-  fHardDefines.Free;
   for I := 0 to fDefines.Count - 1 do
     if not PDefine(fDefines.Objects[i])^.HardCoded then // has already been released
       Dispose(PDefine(fDefines.Objects[i]));
   fDefines.Free;
+  for I := 0 to fHardDefines.Count - 1 do
+    Dispose(PDefine(fHardDefines.Objects[i]));
+  fHardDefines.Free;
   fBranchResults.Free;
   fResult.Free;
   inherited Destroy;

--- a/Source/VCL/ClassBrowsing/StatementList.pas
+++ b/Source/VCL/ClassBrowsing/StatementList.pas
@@ -140,21 +140,22 @@ end;
 procedure TStatementList.DisposeNode(Node: PStatementNode);
 begin
   // remove it from parent's children
-  if Assigned(Node^.Data^._Parent) then begin
-    Node^.Data^._Parent._Children.remove(Node^.Data)
-  end else begin
-    fGlobalStatements.Remove(Node^.Data);
-  end;
-  if OwnsObjects then begin
-    if Assigned(PStatement(Node^.Data)^._InheritanceList) then
-      PStatement(Node^.Data)^._InheritanceList.Free;
-    if Assigned(PStatement(Node^.Data)^._Children) then
-      PStatement(Node^.Data)^._Children.Free;
-    if Assigned(PStatement(Node^.Data)^._Friends) then
-      PStatement(Node^.Data)^._Friends.Free;
-    Dispose(PStatement(Node^.Data));
-  end;
-  Dispose(Node);
+    if Assigned(Node^.Data^._Parent)  then begin
+      Node^.Data^._Parent^._Children.remove(Node^.Data);
+    end else begin
+      fGlobalStatements.Remove(Node^.Data);
+    end;
+
+    if Assigned(PStatement(Node^.Data)) and OwnsObjects then begin
+      if Assigned(PStatement(Node^.Data)^._InheritanceList) then
+        PStatement(Node^.Data)^._InheritanceList.Free;
+      if Assigned(PStatement(Node^.Data)^._Children) then
+        PStatement(Node^.Data)^._Children.Free;
+      if Assigned(PStatement(Node^.Data)^._Friends) then
+        PStatement(Node^.Data)^._Friends.Free;
+      Dispose(PStatement(Node^.Data));
+    end;
+  Dispose(PStatementNode(Node));
 end;
 
 procedure TStatementList.OnNodeDeleting(Node: PStatementNode);

--- a/Source/VCL/ClassBrowsing/StatementList.pas
+++ b/Source/VCL/ClassBrowsing/StatementList.pas
@@ -272,7 +272,8 @@ begin
       NextNode := Node^.NextNode;
       // Do not call OnNodeDeleting, because all nodes will be cleared
       statement := PStatement(Node^.Data);
-      Add(Format('%s,%s,%d',[statement^._Command,statement^._Type,integer(statement^._Parent)]));
+      Add(Format('%s,%s,%d,%s,%d,%s,%d',[statement^._Command,statement^._Type,integer(statement^._Parent)
+        ,statement^._FileName,statement^._Line,statement^._DefinitionFileName,statement^._DefinitionLine]));
       Node := NextNode;
     end;
     SaveToFile(Filename);

--- a/Source/Version.pas
+++ b/Source/Version.pas
@@ -32,7 +32,7 @@ const
 
   // exe properties
   DEVCPP = 'Dev-C++ 2020';
-  DEVCPP_VERSION = '6-beta5';
+  DEVCPP_VERSION = '6-beta5.1';
 
   // delimiters
   DEV_INTERNAL_OPEN = '$__DEV_INTERNAL_OPEN';

--- a/Source/main.pas
+++ b/Source/main.pas
@@ -1628,7 +1628,8 @@ begin
   finally
     ClassBrowser.EndUpdate;
   end;
-  UpdateFileEncodingStatusPanel
+  RebuildClassesToolbar;
+  UpdateFileEncodingStatusPanel;
 end;
 
 procedure TMainForm.OpenFile(const FileName: AnsiString; OpenUseUTF8: boolean);
@@ -1695,6 +1696,7 @@ begin
   finally
     ClassBrowser.EndUpdate;
   end;
+  RebuildClassesToolbar;
 end;
 
 procedure TMainForm.AddFindOutputItem(const line, col, filename, msg, keyword: AnsiString);
@@ -2205,6 +2207,7 @@ begin
   finally
     ClassBrowser.EndUpdate;
   end;
+  RebuildClassesToolbar;
 end;
 
 procedure TMainForm.actCloseProjectExecute(Sender: TObject);
@@ -2269,6 +2272,7 @@ begin
     finally
       ClassBrowser.EndUpdate;
     end;
+    RebuildClassesToolbar;
   finally
     FileMonitor.EndUpdate;
   end;
@@ -4101,6 +4105,8 @@ begin
   finally
     ClassBrowser.EndUpdate;
   end;
+  RebuildClassesToolbar;
+
 
   // Configure class browser actions
   actBrowserViewAll.Checked := ClassBrowser.ShowFilter = sfAll;
@@ -4763,6 +4769,7 @@ begin
   finally
     ClassBrowser.EndUpdate;
   end;
+  RebuildClassesToolbar;
 end;
 
 procedure TMainForm.lvBacktraceCustomDrawItem(Sender: TCustomListView;
@@ -5132,8 +5139,7 @@ begin
   // Loading...
   Screen.Cursor := crHourglass;
 
-  // Pause updating the class browser (which will be invalidated)
-  ClassBrowser.BeginUpdate;
+  //don't call classbrowser to beginupdate, CppParser will do it
 
   // Hide anything that uses the database (which will be invalidated)
   e := fEditorList.GetEditor;
@@ -5169,11 +5175,7 @@ var
 begin
   Screen.Cursor := crDefault;
 
-  // Done. Rebuild stuff that uses the database
-  RebuildClassesToolbar;
-
-  // The class browser can redraw again
-  ClassBrowser.EndUpdate;
+  //CppParser will call class browser to redraw, don't do it twice
 
   // do this work only if this was the last file scanned
   ParseTimeFloat := (GetTickCount - fParseStartTime) / 1000;

--- a/Source/main.pas
+++ b/Source/main.pas
@@ -1017,6 +1017,7 @@ end;
 
 procedure TMainForm.FormClose(Sender: TObject; var Action: TCloseAction);
 begin
+  CppParser.Enabled := False; // disable parser, because we are exiting;
   // Try to close the current project. If it stays open (user says cancel), stop quitting
   if Assigned(fProject) then
     actCloseProjectExecute(Self);


### PR DESCRIPTION
  - fix: crash when exit if Class B inheritanced Class A, and Class C inherited Class B
  - fix: only update class browser when file is open/saved, in case it refreshes frequently.
  - fix: #define in header files lost when reparsing files
