### PR TITLE
- fix: gdb.exe included in the gcc 10.2 distribution may fail to debug

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,9 @@
+Version 6.7.1 MAY 2021
+    
+    - fix: gdb.exe included in the gcc 10.2 distribution may fail to debug
+    - fix: the title for the include and lib tabs in project option dialog are wrong.
+    - fix: add LANG=en environment variable  when run gcc -v to get compiler infos, to prevent it use locale translations
+
 Version 6.7 MAY 2021
     
     highlights:

--- a/Source/ProjectOptionsFrm.dfm
+++ b/Source/ProjectOptionsFrm.dfm
@@ -71,7 +71,7 @@ object ProjectOptionsFrm: TProjectOptionsFrm
     Top = 0
     Width = 712
     Height = 481
-    ActivePage = tabGeneral
+    ActivePage = tabFilesDir
     TabOrder = 3
     object tabGeneral: TTabSheet
       Caption = 'General'
@@ -506,7 +506,7 @@ object ProjectOptionsFrm: TProjectOptionsFrm
         Width = 660
         Height = 28
         Style = csDropDownList
-        ItemHeight = 0
+        ItemHeight = 20
         TabOrder = 1
         OnChange = cmbCompilerChange
       end

--- a/Source/ProjectOptionsFrm.pas
+++ b/Source/ProjectOptionsFrm.pas
@@ -706,8 +706,8 @@ begin
 
   // Directories tab
   SubTabs.Tabs.Clear;
-  SubTabs.Tabs.Append(Lang[ID_POPT_INCDIRS]);
   SubTabs.Tabs.Append(Lang[ID_POPT_LIBDIRS]);
+  SubTabs.Tabs.Append(Lang[ID_POPT_INCDIRS]);
   SubTabs.Tabs.Append(Lang[ID_POPT_RESDIRS]);
   btnDirReplace.Caption := Lang[ID_BTN_REPLACE];
   btnDirAdd.Caption := Lang[ID_BTN_ADD];

--- a/Source/devCFG.pas
+++ b/Source/devCFG.pas
@@ -1333,8 +1333,9 @@ begin
   output := GetCompilerOutput(BinDir + pd, BinFile, '-v');
   //Target
   DelimPos1 := Pos('Target: ', output);
-  if DelimPos1 = 0 then
-    Exit; // unknown binary
+  if DelimPos1 = 0 then begin
+    Exit
+  end;
   Inc(DelimPos1, Length('Target: '));
   DelimPos2 := DelimPos1;
   while (DelimPos2 <= Length(output)) and not (output[DelimPos2] in [#0..#32]) do
@@ -1729,8 +1730,11 @@ begin
 end;
 
 function TdevCompilerSet.GetCompilerOutput(const BinDir, BinFile, Input: AnsiString): AnsiString;
+var
+  env:string;
 begin
-  result := Trim(RunAndGetOutput(BinDir + pd + BinFile + ' ' + Input, BinDir, nil, nil, false))
+  env:='LANG=en'#0#0;
+  result := Trim(RunAndGetOutput(BinDir + pd + BinFile + ' ' + Input, BinDir, nil, nil, false, PChar(env)))
 end;
 
 function TdevCompilerSet.ValidateDirs(var msg:string): boolean;


### PR DESCRIPTION
    - fix: the title for the include and lib tabs in project option dialog are wrong. （close #179 )
    - fix: add LANG=en environment variable  when run gcc -v to get compiler infos, to prevent it use locale translations (close #180 )