### PR TITLE
* fix: show value of the variable under cursor when debugging

### DIFF
--- a/Source/DataFrm.pas
+++ b/Source/DataFrm.pas
@@ -429,6 +429,9 @@ begin
       else if (CompareText(ext, '.html')  = 0)
         or (CompareText(ext, '.htm')  = 0)then
         result := HTMLSyn
+      else if (CompareText(ext, '.s')  = 0)
+        or (CompareText(ext, '.asm')  = 0)then
+        result := AsmSyn
       else if (CompareText(ext, '.js')  = 0) then
         result := JSSyn
       else if CompareText(ext, '.css') = 0 then

--- a/Source/Utils.pas
+++ b/Source/Utils.pas
@@ -37,6 +37,7 @@ type
     utresSrc, // resource source (.rc)
     utPrj, // project file (.dev)
     utMakefile, // makefile (.win)
+    utasmSrc, // asm source file
     utOther // any others
     );
 
@@ -943,6 +944,8 @@ begin
     result := utresSrc
   else if AnsiMatchText(ext, ['.rh']) then
     result := utresHead
+  else if AnsiMatchText(ext, ['.asm','.s']) then
+    result := utasmSrc
   else
     result := utOther;
 end;

--- a/Source/Version.pas
+++ b/Source/Version.pas
@@ -32,7 +32,7 @@ const
 
   // exe properties
   DEVCPP = 'Red Panda Dev-C++';
-  DEVCPP_VERSION = '6.7.1';
+  DEVCPP_VERSION = '6.7.2';
 
   // delimiters
   DEV_INTERNAL_OPEN = '$__DEV_INTERNAL_OPEN';


### PR DESCRIPTION
 * fix: show value of the variable under cursor when debugging
 * add: open .asm file with assembly language highlighter